### PR TITLE
Keep the name of the app short, the description is meant to happen in the description key ;)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "Biboumi XMPP->IRC Gateway",
+    "name": "Biboumi",
     "id": "biboumi",
     "packaging_format": 1,
     "description": {


### PR DESCRIPTION
Currently this create CSS rendering issue on the app catalog because the name is too long :S 